### PR TITLE
Add support for multiple `busStopCodes`

### DIFF
--- a/MMM-MTA-NextBus.js
+++ b/MMM-MTA-NextBus.js
@@ -12,7 +12,8 @@ Module.register("MMM-MTA-NextBus", {
 		timeFormat: config.timeFormat,
 		maxEntries: 5,
 		updateInterval: 60000,
-		retryDelay: 5000
+		retryDelay: 5000,
+		busStopCodes: [],
 	},
 
 	requiresVersion: "2.1.0", // Required version of MagicMirror
@@ -78,50 +79,53 @@ Module.register("MMM-MTA-NextBus", {
 		//this.sendSocketNotification("MMM-MTA-NextBus-NOTIFICATION_TEST", data);
 	},
 
-	processActionNextBus: function(response) {
-		
+	processActionNextBus: function(responses) {
 		var result = [];
-		
-		var serviceDelivery = response.Siri.ServiceDelivery;
-		var updateTimestampReference = new Date(serviceDelivery.ResponseTimestamp);
-		
-		//console.log(updateTimestampReference);
-		
-		// array of buses
-		var visits = serviceDelivery.StopMonitoringDelivery[0].MonitoredStopVisit;
-		var visitsCount = Math.min(visits.length, this.config.maxEntries);
-		
-		for (var i = 0; i < visitsCount; i++) {
+		let journeys = []
+		const updateTimestampReference = new Date()
+		for (var response of responses) {
+			var serviceDelivery = response.Siri.ServiceDelivery;
+
+			var monitoringDeliveries = serviceDelivery.StopMonitoringDelivery
+			for (var monitoringDelivery of monitoringDeliveries) {
+				var visits = monitoringDelivery?.MonitoredStopVisit ?? [];
+
+				for (var visit of visits) {
+					journeys.push(visit.MonitoredVehicleJourney)
+				}
+			}
+		}
+
+		journeys.sort((a, b) => {
+			return new Date(a.MonitoredCall.ExpectedArrivalTime) - new Date(b.MonitoredCall.ExpectedArrivalTime)
+		})
+
+		journeys = journeys.slice(0, Math.min(journeys.length, this.config.maxEntries))
+
+		for (var journey of journeys) {
 			r = '';
 
-			var journey = visits[i].MonitoredVehicleJourney;
-			var line = journey.PublishedLineName[0]; 
-			
+			var line = journey.PublishedLineName[0];
+
 			var destinationName = journey.DestinationName[0];
 			if (destinationName.startsWith('LIMITED')) {
 				line += ' LIMITED';
 			}
-			
+
 			r += line + ', ';
-			
+
 			var monitoredCall = journey.MonitoredCall;
-			// var expectedArrivalTime = new Date(monitoredCall.ExpectedArrivalTime);
-			if (monitoredCall.ExpectedArrivalTime) {
-				var mins = this.getArrivalEstimateForDateString(monitoredCall.ExpectedArrivalTime, updateTimestampReference);
-				r += mins + ', ';
-			}
-			
-			
+			var mins = this.getArrivalEstimateForDateString(monitoredCall.ExpectedArrivalTime, updateTimestampReference);
+			r += mins + ', ';
+
 			var distance = monitoredCall.ArrivalProximityText;
 			r += distance;
 
 			result.push(r);
 		}
 
-
-
 		result.push('Last Updated: ' + this.formatTimeString(updateTimestampReference));
-		
+
 		return result;
 	},
 

--- a/README.md
+++ b/README.md
@@ -25,9 +25,9 @@ var config = {
 ## Configuration options
 
 | Option           | Description
-|----------------- |-----------
+|------------------|-----------
 | `apiKey`         | *Required* Your MTA Bus Time API key. If you don't have one, you can request one [here](http://spreadsheets.google.com/viewform?hl=en&formkey=dG9kcGIxRFpSS0NhQWM4UjA0V0VkNGc6MQ#gid=0).<br><br> **Type:** `string` <br> **Default value:** `none`
-| `busStopCode`    | *Required* The 6 digit bus stop code to monitor. You can get it from your bus stop or find it [here](http://bustime.mta.info/).<br><br> **Type:** `string` <br> **Default value:** `none`
+| `busStopCodes`   | *Required* The 6 digit bus stop code to monitor. You can get it from your bus stop or find it [here](http://bustime.mta.info/).<br><br> **Type:** `array[string]` <br> **Example value:** `['302278', '303845']` <br> **Default value:** `[]`
 | `timeFormat`     | *Optional* Use 12 or 24 hour format. <br><br> **Possible values:** `12` or `24` <br> **Default value:** uses value of _config.timeFormat_
 | `maxEntries`     | *Optional* The maximum number of buses to display. <br><br> **Possible values:** `1` to `10` <br> **Default value:** `5`
 | `updateInterval` | *Optional* How often to check for the next bus. <br><br> **Type:** `int`<br> **Default value:** `60000` milliseconds (1 minute)

--- a/node_helper.js
+++ b/node_helper.js
@@ -6,7 +6,6 @@
  */
 
 var NodeHelper = require("node_helper");
-var http = require('http');
 
 module.exports = NodeHelper.create({
 
@@ -59,39 +58,23 @@ module.exports = NodeHelper.create({
 	 * get a URL request
 	 *
 	 */
-	getData: function() {
+	getData: async function() {
 		var self = this;
+		var responses = []
+		try {
+			for (var busStopCode of self.config.busStopCodes) {
+				var urlApi = "http://bustime.mta.info/api/siri/stop-monitoring.json?key=" +
+					self.config.apiKey + "&version=2&OperatorRef=MTA&MonitoringRef=" +
+					busStopCode;
 
-		var urlApi = "http://bustime.mta.info/api/siri/stop-monitoring.json?key=" + 
-			self.config.apiKey + "&version=2&OperatorRef=MTA&MonitoringRef=" + 
-			self.config.busStopCode;
-		
-		//var retry = true;
-
-		http.get(urlApi, function(res) {
-			var responseString = "";
-
-			if (res.statusCode === 401) {
-				self.sendSocketNotification("ERROR", this.status);
-				console.log(self.name, this.status);
-				//retry = false;
-			} else if (res.statusCode != 200) {
-				console.log(self.name, "Could not load data.");
-				//self.scheduleUpdate((self.loaded) ? -1 : self.config.retryDelay);
-			} 
-
-			res.on('data', function(data) {
-				responseString += data;
-			});
-			
-			res.on('end', function() {
-				self.sendSocketNotification("DATA", JSON.parse(responseString));
-			});
-
-		}).on('error', function(e) {
-			console.log("Communications error:", e.message);
-			//self.scheduleUpdate((self.loaded) ? -1 : self.config.retryDelay);
-		});
+				const response = await fetch(urlApi)
+				const schedule = await response.json()
+				responses.push(schedule)
+			}
+			self.sendSocketNotification("DATA", responses);
+		} catch {
+			self.sendSocketNotification("ERROR", this.status);
+			console.log(self.name, this.status);
+		}
 	}
-
 });


### PR DESCRIPTION
Add ability to pull bus data from multiple bus stops at the same time. Sorts buses by estimated arrival time.

Add config option `busStopCodes` which takes an array of MTA bus stop codes.
```javascript
{
    module: 'MMM-MTA-NextBus',
    position: "bottom_right",
    config: {
        apiKey: 'API-KEY',
        busStopCodes: ['302278', '303845']
    }
}
```

![image](https://github.com/user-attachments/assets/79a56e55-54bb-46ad-8122-e6dd28930510)
